### PR TITLE
Fix select item outline label overlap problem, caused by mismatch

### DIFF
--- a/src/simple-editor/agents/ToolEditor.tsx
+++ b/src/simple-editor/agents/ToolEditor.tsx
@@ -175,7 +175,7 @@ const ToolEditor : React.FC<ToolEditorProps> = ({
                             labelId="type-label"
                             id="type-select"
                             value={tool.type}
-                            label="Tool type"
+                            label="Tool Options"
                             onChange={(e) => setType(e.target.value)}
                             sx={{minHeight: '6rem'}}
                         >
@@ -306,7 +306,7 @@ const ToolEditor : React.FC<ToolEditorProps> = ({
                                         <Select
                                             labelId = { 'arg-type-' + ix }
                                             value={arg.type}
-                                            label="Type"
+                                            label="Argument Type"
                                             onChange={
                                                 (e) =>
                                                     setArgType(

--- a/src/simple-editor/model-params/ModelParameters.tsx
+++ b/src/simple-editor/model-params/ModelParameters.tsx
@@ -46,7 +46,7 @@ const ModelParameters: React.FC<ModelParametersProps> = ({
                         labelId="model-name-label"
                         id="model-name-select"
                         value="n/a"
-                        label="Model deployment"
+                        label="Model"
                     >
                         <MenuItem key="n/a" value="n/a">n/a</MenuItem>
                     </Select>
@@ -64,7 +64,7 @@ const ModelParameters: React.FC<ModelParametersProps> = ({
                     labelId="model-name-label"
                     id="model-name-select"
                     value={modelName}
-                    label="Model deployment"
+                    label="Model"
                     onChange={(e) => onModelNameChange(e.target.value)}
                     inputProps={{ readOnly: readOnly }}
                 >

--- a/src/simple-editor/model-params/VectorDB.tsx
+++ b/src/simple-editor/model-params/VectorDB.tsx
@@ -15,7 +15,7 @@ const VectorDB: React.FC<VectorDBProps> = ({ value, onChange }) => {
 
         <FormControl fullWidth>
 
-            <InputLabel id="graph-store-label">VectorDB</InputLabel>
+            <InputLabel id="graph-store-label">Vector DB</InputLabel>
 
             <Select
                 labelId="vector-db-label"


### PR DESCRIPTION
Fix select item outline label overlap problem, caused by mismatch label attributes.
