### PR TITLE
Fix agent argument UX not matching workflow

### DIFF
--- a/src/simple-editor/agents/ToolArgument.tsx
+++ b/src/simple-editor/agents/ToolArgument.tsx
@@ -49,6 +49,7 @@ const ToolArgument : React.FC<ToolArgumentProps> = ({
                                 );
                             }
                         }
+                        disabled
                     />
                 </Grid>
 
@@ -68,6 +69,7 @@ const ToolArgument : React.FC<ToolArgumentProps> = ({
                                         ix, e.target.value
                                     )
                             }
+                            disabled
                         >
                             <MenuItem value="string">
                                 string
@@ -88,6 +90,8 @@ const ToolArgument : React.FC<ToolArgumentProps> = ({
                 >
 
                     <Box>
+{ /*
+
                         <Button
                             startIcon={<Delete/>}
                             variant="contained"
@@ -95,6 +99,7 @@ const ToolArgument : React.FC<ToolArgumentProps> = ({
                         >
                             Delete
                         </Button>
+  */ }
                     </Box>
 
                 </Grid>

--- a/src/simple-editor/agents/ToolDefinition.tsx
+++ b/src/simple-editor/agents/ToolDefinition.tsx
@@ -23,12 +23,6 @@ const ToolDefinition : React.FC<ToolDefinitionProps> = ({
 
         <Paper elevation={3} sx={{p: 3}}>
 
-{/*
-            <Typography variant="h5" component="h2" gutterBottom>
-                Definition
-            </Typography>
-*/}
-
             <Grid container spacing={2}>
 
                 <Grid size={{ xs: 12, md: 4 }}>
@@ -79,7 +73,10 @@ const ToolDefinition : React.FC<ToolDefinitionProps> = ({
                                 <Stack
                                     direction="row" spacing={2}
                                     divider={
-                                        <Divider orientation="vertical" flexItem/>
+                                        <Divider
+                                            orientation="vertical"
+                                            flexItem
+                                        />
                                     }
                                 >
 
@@ -113,7 +110,10 @@ const ToolDefinition : React.FC<ToolDefinitionProps> = ({
                                 <Stack
                                     direction="row" spacing={2}
                                     divider={
-                                        <Divider orientation="vertical" flexItem/>
+                                        <Divider
+                                            orientation="vertical"
+                                            flexItem
+                                        />
                                     }
                                 >
 

--- a/src/simple-editor/agents/ToolEditor.tsx
+++ b/src/simple-editor/agents/ToolEditor.tsx
@@ -56,7 +56,59 @@ const ToolEditor : React.FC<ToolEditorProps> = ({
     };
 
     const setType = (type : string) => {
-        updateTool((t) => ({ ...t, type: type }));
+        if (type == "text-completion") {
+            updateTool(
+                (t) => {
+console.log(t);
+                    let newArgs = t.arguments.filter(
+                        (a) => (a.name == "question")
+                    )
+
+                    if (newArgs.length < 1) {
+                        newArgs.push({
+                            name: "question",
+                            type: "string",
+                            description: "A simple natural language question.",
+                        });
+                    }
+
+                    return {
+                        ...t,
+                        type: type,
+                        arguments: newArgs,
+                        description: "This tool queries an LLM for further information.  The query should be a natural language question.",
+                    };
+
+                }
+            );
+        } else if (type == "knowledge-query") {
+            updateTool(
+                (t) => {
+
+                    let newArgs = t.arguments.filter(
+                        (a) => (a.name == "query")
+                    )
+
+                    if (newArgs.length < 1) {
+                        newArgs.push({
+                            name: "query",
+                            type: "string",
+                            description: "A simple natural language question.",
+                        });
+                    }
+
+                    return {
+                        ...t,
+                        type: type,
+                        description: "This tool queries a knowledge base that holds information about XYZ.  The query should be a natural language question.",
+                        arguments: newArgs,
+                    };
+
+                }
+            );
+        } else {
+            console.log("Unexpected tool type:", type);
+        }
     };
 
     const setName = (name : string) => {
@@ -156,6 +208,7 @@ const ToolEditor : React.FC<ToolEditorProps> = ({
 
                 <Stack spacing={3} direction="row">
 
+{ /*
                     <Box>
 
                         {
@@ -169,6 +222,7 @@ const ToolEditor : React.FC<ToolEditorProps> = ({
                         }
 
                     </Box>
+*/ }
 
                     <Box>
 

--- a/src/simple-editor/state/Agents.ts
+++ b/src/simple-editor/state/Agents.ts
@@ -34,12 +34,12 @@ export const useAgentsStore = create<Agents>()(
                 name: "Sample query",
                 type: "knowledge-query",
                 config: {},
-                description: "Query a knowledge base that has already been extracted.  The query should be a simple natural language question.",
+                description: "This tool queries a knowledge base that holds information about XYZ.  The query should be a natural language question.",
                 arguments: [
                     {
                         name: "query",
                         type: "string",
-                        description: "Describe the search query here.",
+                        description: "A simple natural language question.",
                     }
                 ]
             },
@@ -48,12 +48,12 @@ export const useAgentsStore = create<Agents>()(
                 name: "Sample text completion",
                 type: "text-completion",
                 config: {},
-                description: "Describe the request to send to LLM. This request will be sent with no additional context.",
+                description: "This tool queries an LLM for further information.  The query should be a natural language question.",
                 arguments: [
                     {
-                        name: "response",
+                        name: "question",
                         type: "string",
-                        description: "The response expected from the LLM.",
+                        description: "The question which should be asked of the LLM.",
                     }
                 ]
             }


### PR DESCRIPTION
- Made the tool argument drop-down (Graph RAG vs Text completion option) change the arguments to match what the function expects.
- Got rid of edit options which don't make sense for the flow: argument deletion, add argument.  Argument name & type are not editable.
